### PR TITLE
Exceptions branch

### DIFF
--- a/src/main/java/com/example/ecommerce_payment_service/Controllers/PaymentController.java
+++ b/src/main/java/com/example/ecommerce_payment_service/Controllers/PaymentController.java
@@ -20,24 +20,21 @@ import java.util.Optional;
 @Slf4j
 public class PaymentController {
     private final IPaymentService paymentService;
-    private final IRefundService refundService;
 
-    public PaymentController(@Qualifier("paymentServiceImpl")IPaymentService paymentService,
-                              @Qualifier("refundServiceImpl")IRefundService refundService) {
+    public PaymentController(@Qualifier("paymentServiceImpl")IPaymentService paymentService) {
         this.paymentService = paymentService;
-        this.refundService = refundService;
     }
 
 
-    // Initiate a new payment for an order
+    // Integrate custom exceptions like
+    // PaymentNotFoundException, InvalidRefundException, and OrderNotFoundException
     @PostMapping
     public ResponseEntity<Payment> createPayment(@Valid @RequestBody Long orderId,
                                                  BigDecimal amount, String paymentMethod) {
         Payment payment = paymentService.createPayment(orderId, amount, paymentMethod);
-        log.info("Payment created: " + payment);
+        log.info("Payment created: {}", payment);
         return ResponseEntity.ok(payment);
     }
-
 
     @PostMapping("/process/{paymentId}")
     public ResponseEntity<Payment> processPayment(@PathVariable("paymentId") Long paymentId) {
@@ -46,7 +43,6 @@ public class PaymentController {
 
         return ResponseEntity.ok(payment);
     }
-
 
     @GetMapping("/{paymentId}")
     public ResponseEntity<Payment> getPaymentById(@PathVariable("paymentId") Long paymentId) {
@@ -62,40 +58,9 @@ public class PaymentController {
         return payments;
     }
 
-
     @GetMapping("/order/{orderId}")
     public List<Payment> getPaymentByOrderId(@PathVariable("orderId") Long orderId) {
         List<Payment> payments = paymentService.getPaymentsByOrderId(orderId);
-
-        return payments;
-    }
-
-    // Refund methods
-
-    @PostMapping("/refund/{paymentId}")
-    public ResponseEntity<Refund> initiateRefund(@PathVariable("paymentId") Long paymentId, Optional<Double> refundAmount) {
-        Refund refund = refundService.initiateRefund(paymentId, refundAmount);
-
-        return ResponseEntity.ok(refund);
-    }
-
-    @GetMapping("/refund/{refundId}")
-    public ResponseEntity<Refund> getRefundById(@PathVariable("refundId") Long refundId) {
-        Refund refund = refundService.getRefundStatus(refundId);
-
-        return ResponseEntity.ok(refund);
-    }
-
-    @PostMapping("/cancel/{paymentId}")
-    public ResponseEntity<Payment> cancelPayment(@PathVariable("paymentId") Long paymentId) {
-        Payment payment = paymentService.getPaymentById(paymentId);
-
-        return ResponseEntity.ok(payment);
-    }
-
-    @GetMapping("/failed")
-    public List<Payment> getPaymentFailed() {
-        List<Payment> payments = refundService.getFailedPayments();
 
         return payments;
     }

--- a/src/main/java/com/example/ecommerce_payment_service/Controllers/RefundController.java
+++ b/src/main/java/com/example/ecommerce_payment_service/Controllers/RefundController.java
@@ -1,0 +1,57 @@
+package com.example.ecommerce_payment_service.Controllers;
+
+
+import com.example.ecommerce_payment_service.Entities.Payment;
+import com.example.ecommerce_payment_service.Entities.Refund;
+import com.example.ecommerce_payment_service.Services.IPaymentService;
+import com.example.ecommerce_payment_service.Services.IRefundService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/payments")
+@Slf4j
+public class RefundController {
+    private final IPaymentService paymentService;
+    private final IRefundService refundService;
+
+    public RefundController(@Qualifier("paymentServiceImpl")IPaymentService paymentService,
+                             @Qualifier("refundServiceImpl")IRefundService refundService) {
+        this.paymentService = paymentService;
+        this.refundService = refundService;
+    }
+
+
+    @PostMapping("/refund/{paymentId}")
+    public ResponseEntity<Refund> initiateRefund(@PathVariable("paymentId") Long paymentId, Optional<Double> refundAmount) {
+        Refund refund = refundService.initiateRefund(paymentId, refundAmount.orElse(null));
+
+        return ResponseEntity.ok(refund);
+    }
+
+    @GetMapping("/refund/{refundId}")
+    public ResponseEntity<Refund> getRefundById(@PathVariable("refundId") Long refundId) {
+        Refund refund = refundService.getRefundStatus(refundId);
+
+        return ResponseEntity.ok(refund);
+    }
+
+    @PostMapping("/cancel/{paymentId}")
+    public ResponseEntity<Payment> cancelPayment(@PathVariable("paymentId") Long paymentId) {
+        Payment payment = paymentService.getPaymentById(paymentId);
+
+        return ResponseEntity.ok(payment);
+    }
+
+    @GetMapping("/failed")
+    public List<Payment> getPaymentFailed() {
+        List<Payment> payments = refundService.getFailedPayments();
+
+        return payments;
+    }
+}

--- a/src/main/java/com/example/ecommerce_payment_service/Controllers/RefundController.java
+++ b/src/main/java/com/example/ecommerce_payment_service/Controllers/RefundController.java
@@ -3,6 +3,8 @@ package com.example.ecommerce_payment_service.Controllers;
 
 import com.example.ecommerce_payment_service.Entities.Payment;
 import com.example.ecommerce_payment_service.Entities.Refund;
+import com.example.ecommerce_payment_service.Exceptions.InvalidRefundException;
+import com.example.ecommerce_payment_service.Exceptions.RefundNotFoundException;
 import com.example.ecommerce_payment_service.Services.IPaymentService;
 import com.example.ecommerce_payment_service.Services.IRefundService;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +31,9 @@ public class RefundController {
 
     @PostMapping("/refund/{paymentId}")
     public ResponseEntity<Refund> initiateRefund(@PathVariable("paymentId") Long paymentId, Optional<Double> refundAmount) {
+        if(refundAmount.get() < 0.0) {
+            throw new InvalidRefundException("Refund amount cannot be negative");
+        }
         Refund refund = refundService.initiateRefund(paymentId, refundAmount.orElse(null));
 
         return ResponseEntity.ok(refund);
@@ -36,6 +41,9 @@ public class RefundController {
 
     @GetMapping("/refund/{refundId}")
     public ResponseEntity<Refund> getRefundById(@PathVariable("refundId") Long refundId) {
+        if(refundService.getRefundStatus(refundId) == null) {
+            throw new RefundNotFoundException("Refund  with id:" + refundId + "not found");
+        }
         Refund refund = refundService.getRefundStatus(refundId);
 
         return ResponseEntity.ok(refund);

--- a/src/main/java/com/example/ecommerce_payment_service/Exceptions/ErrorDetails.java
+++ b/src/main/java/com/example/ecommerce_payment_service/Exceptions/ErrorDetails.java
@@ -1,0 +1,14 @@
+package com.example.ecommerce_payment_service.Exceptions;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class ErrorDetails {
+    private LocalDateTime timestamp;
+    private String message;
+    private String details;
+}

--- a/src/main/java/com/example/ecommerce_payment_service/Exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/ecommerce_payment_service/Exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.example.ecommerce_payment_service.Exceptions;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    // Handle Payment Not Found exception
+    @ExceptionHandler(PaymentNotFoundException.class)
+    public ResponseEntity<ErrorDetails> handlePaymentNotFoundException(PaymentNotFoundException ex, WebRequest request) {
+        return buildErrorResponse(ex, HttpStatus.NOT_FOUND, request);
+    }
+
+    // Handle Invalid Refund exception
+    @ExceptionHandler(InvalidRefundException.class)
+    public ResponseEntity<ErrorDetails> handleInvalidRefundException(InvalidRefundException ex, WebRequest request) {
+        return buildErrorResponse(ex, HttpStatus.BAD_REQUEST, request);
+    }
+
+    // Handle Order Not Found exception
+    @ExceptionHandler(OrderNotFoundException.class)
+    public ResponseEntity<ErrorDetails> handleOrderNotFoundException(OrderNotFoundException ex, WebRequest request) {
+        return buildErrorResponse(ex, HttpStatus.UNAUTHORIZED, request);
+    }
+
+    // Handle Order Not Found exception
+    @ExceptionHandler(RefundNotFoundException.class)
+    public ResponseEntity<ErrorDetails> handleRefundNotFoundException(RefundNotFoundException ex, WebRequest request) {
+        return buildErrorResponse(ex, HttpStatus.UNAUTHORIZED, request);
+    }
+
+    // Generic Exception Handler (Fallback for Unhandled Exceptions)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorDetails> handleGlobalException(Exception ex, WebRequest request) {
+        return buildErrorResponse(ex, HttpStatus.INTERNAL_SERVER_ERROR, request);
+    }
+
+    // Helper method to build an error response
+    private ResponseEntity<ErrorDetails> buildErrorResponse(Exception ex, HttpStatus status, WebRequest request) {
+        ErrorDetails errorDetails = new ErrorDetails(
+                LocalDateTime.now(),
+                ex.getMessage(),
+                request.getDescription(false)
+        );
+        return new ResponseEntity<>(errorDetails, status);
+    }
+}

--- a/src/main/java/com/example/ecommerce_payment_service/Exceptions/InvalidRefundException.java
+++ b/src/main/java/com/example/ecommerce_payment_service/Exceptions/InvalidRefundException.java
@@ -1,0 +1,11 @@
+package com.example.ecommerce_payment_service.Exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class InvalidRefundException extends RuntimeException {
+    public InvalidRefundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/ecommerce_payment_service/Exceptions/OrderNotFoundException.java
+++ b/src/main/java/com/example/ecommerce_payment_service/Exceptions/OrderNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.ecommerce_payment_service.Exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class OrderNotFoundException extends RuntimeException {
+    public OrderNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/ecommerce_payment_service/Exceptions/PaymentNotFoundException.java
+++ b/src/main/java/com/example/ecommerce_payment_service/Exceptions/PaymentNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.ecommerce_payment_service.Exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class PaymentNotFoundException extends RuntimeException {
+    public PaymentNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/ecommerce_payment_service/Exceptions/RefundNotFoundException.java
+++ b/src/main/java/com/example/ecommerce_payment_service/Exceptions/RefundNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.ecommerce_payment_service.Exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class RefundNotFoundException extends RuntimeException {
+    public RefundNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/ecommerce_payment_service/Services/IRefundService.java
+++ b/src/main/java/com/example/ecommerce_payment_service/Services/IRefundService.java
@@ -14,7 +14,7 @@ public interface IRefundService {
     //public Refund initiateRefund(Long paymentId);
 
     // method with optional parameter
-    Refund initiateRefund(Long paymentId, Optional<Double> refundAmount);
+    Refund initiateRefund(Long paymentId, Double refundAmount);
 
     // Check the status of a Refund
     Refund getRefundStatus(Long refundId);

--- a/src/main/java/com/example/ecommerce_payment_service/Services/PaymentServiceImpl.java
+++ b/src/main/java/com/example/ecommerce_payment_service/Services/PaymentServiceImpl.java
@@ -26,18 +26,13 @@ public class PaymentServiceImpl implements IPaymentService{
     @Override
     public Payment createPayment(Long orderId, BigDecimal amount, String paymentMethod) {
 
-        log.info("Payment object is being created");
         Payment payment = new Payment();
 
-        try {
-            payment.setOrderId(orderId);
-            payment.setAmount(amount);
-            payment.setStatus(PaymentStatus.INITIATED);
-            payment.setTransactionId(paymentMethod + "_" + randomUUID()); //Generate unique identifier using paymentMethod and unique UUID
-        }
-        catch (Exception e) {
-            e.printStackTrace();
-        }
+        payment.setOrderId(orderId);
+        payment.setAmount(amount);
+        payment.setStatus(PaymentStatus.INITIATED);
+        payment.setTransactionId(paymentMethod + "_" + randomUUID()); //Generate unique identifier using paymentMethod and unique UUID
+
         return paymentRepository.save(payment);
     }
 
@@ -49,21 +44,15 @@ public class PaymentServiceImpl implements IPaymentService{
         boolean thirdPartyServiceAcceptedPayment;
         Payment ongoingPayment = new Payment();
 
-        try {
-            ongoingPayment = paymentRepository.getReferenceById(payment.getId());
-            // Place to insert third-party gateway to handle payment
-            thirdPartyServiceAcceptedPayment = true;
+        ongoingPayment = paymentRepository.getReferenceById(payment.getId());
+        // Place to insert third-party gateway to handle payment
+        thirdPartyServiceAcceptedPayment = true;
 
-            if(thirdPartyServiceAcceptedPayment) {
-                ongoingPayment.setStatus(PaymentStatus.COMPLETED);
-            }
-            else {  // if third-party gateway rejected the payment
-                ongoingPayment.setStatus(PaymentStatus.CANCELLED);
-            }
+        if(thirdPartyServiceAcceptedPayment) {
+            ongoingPayment.setStatus(PaymentStatus.COMPLETED);
         }
-        catch(Exception e) {
-            ongoingPayment.setStatus(PaymentStatus.FAILED);
-            e.printStackTrace();    //
+        else {  // if third-party gateway rejected the payment
+            ongoingPayment.setStatus(PaymentStatus.CANCELLED);
         }
 
         return ongoingPayment;
@@ -74,13 +63,7 @@ public class PaymentServiceImpl implements IPaymentService{
     public Payment getPaymentById(Long paymentId)
     {
         Payment payment = new Payment();
-
-        try {
-            payment = paymentRepository.getReferenceById(paymentId);
-        }
-        catch(Exception e) {
-            e.printStackTrace();    //
-        }
+        payment = paymentRepository.getReferenceById(paymentId);
 
         return payment;
     }
@@ -90,13 +73,7 @@ public class PaymentServiceImpl implements IPaymentService{
     public List<Payment> getPaymentsByUserId(Long userId)
     {
         List<Payment> payments = new ArrayList<>();
-
-        try {
-            payments = paymentRepository.findByUserId(userId);
-        }
-        catch(Exception e) {
-            e.printStackTrace();    //
-        }
+        payments = paymentRepository.findByUserId(userId);
 
         return payments;
     }
@@ -106,13 +83,7 @@ public class PaymentServiceImpl implements IPaymentService{
     public List<Payment> getPaymentsByOrderId(Long orderId)
     {
         List<Payment> payments = new ArrayList<>();
-
-        try {
-            payments = paymentRepository.findByOrderId(orderId);
-        }
-        catch(Exception e) {
-            e.printStackTrace();    //
-        }
+        payments = paymentRepository.findByOrderId(orderId);
 
         return payments;
     }

--- a/src/main/java/com/example/ecommerce_payment_service/Services/RefundServiceImpl.java
+++ b/src/main/java/com/example/ecommerce_payment_service/Services/RefundServiceImpl.java
@@ -25,33 +25,19 @@ public class RefundServiceImpl implements IRefundService {
         this.paymentRepository = paymentRepository;
     }
 
-//    @Override
-//    @Transactional
-//    // Start a refund process for a completed Payment
-//    public Refund initiateRefund(Long paymentId) {
-//        Payment payment = paymentRepository.findById(paymentId).orElse(null);
-//        Refund refund = new Refund();
-//        if(payment == null) {
-//            refund.setRefundAmount(0.0);
-//            refund.setStatus(RefundStatus.FAILED);
-//            refund.setReason("");   //should we get a refund object from database or should we create it inside this method?
-//        }
-//        return refund;  //not sure
-//    }
-
     @Override
     @Transactional
-    public Refund initiateRefund(Long paymentId, Optional<Double> refundAmount) {
+    public Refund initiateRefund(Long paymentId, Double refundAmount) {
         Optional<Payment> paymentOpt = paymentRepository.findById(paymentId);
         Payment payment = paymentOpt.get();
-        if (!refundAmount.isPresent()) {
+        if (refundAmount == null) {
             log.error("Refund amount is not specified, minimum value is being assigned");
-            refundAmount = Optional.of(refundAmount.orElse(0.0));
+            refundAmount = 0.0;
         }
 
         Refund refund = new Refund();
         refund.setPayment(payment);
-        refund.setRefundAmount(refundAmount.get());
+        refund.setRefundAmount(refundAmount);
         refund.setStatus(RefundStatus.PENDING);
 
         return refundRepository.save(refund);


### PR DESCRIPTION
### **Implemented GlobalExceptionsHandler class to handle custom exceptions**

**Payment-related Exceptions:**
PaymentNotFoundException
OrderNotFoundException

**Refund-related Exceptions:**
InvalidRefundException
RefundNotFoundException

**Question:** In almost all my endpoints I receive parameters of the object, not the object itself, Is it possible to add WebRequest information while throwing an Exception?
Example: 
```
    @PostMapping("/process/{paymentId}")
    public ResponseEntity<Payment> processPayment(@PathVariable("paymentId") Long paymentId) {
        if(paymentService.getPaymentById(paymentId) == null) {
            log.warn("Payment with id:{} cannot be found", paymentId);
            throw new PaymentNotFoundException("Payment not found");    // is it possible to add WebRequest details here?
        }
```
It could look like this if I would have payment object:
`throw new PaymentNotFoundException("Payment not found", payment.getId());`