### PR TITLE
Kafka payment confirmation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,13 @@
 			<version>3.2.0</version>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka -->
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+			<version>3.3.4</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>

--- a/src/main/java/com/example/ecommerce_payment_service/dto/PaymentConfirmedEvent.java
+++ b/src/main/java/com/example/ecommerce_payment_service/dto/PaymentConfirmedEvent.java
@@ -1,0 +1,13 @@
+package com.example.ecommerce_payment_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PaymentConfirmedEvent {
+    private Long orderId;
+    private String status; // Should match the enum in the order service
+}

--- a/src/main/java/com/example/ecommerce_payment_service/kafka/KafkaProducerConfig.java
+++ b/src/main/java/com/example/ecommerce_payment_service/kafka/KafkaProducerConfig.java
@@ -1,0 +1,32 @@
+package com.example.ecommerce_payment_service.kafka;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/example/ecommerce_payment_service/kafka/PaymentEventPublisher.java
+++ b/src/main/java/com/example/ecommerce_payment_service/kafka/PaymentEventPublisher.java
@@ -1,0 +1,31 @@
+package com.example.ecommerce_payment_service.kafka;
+
+import com.example.ecommerce_payment_service.dto.PaymentConfirmedEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentEventPublisher {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    public void sendPaymentConfirmedEvent(Long orderId, String transactionId) {
+        String topic = "payment-confirmed";
+        try {
+            String message = objectMapper.writeValueAsString(new PaymentConfirmedEvent(orderId, "PAID"));
+            kafkaTemplate.send(topic, message);
+            log.info("Sent payment-confirmed event: {}", message);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize PaymentConfirmedEvent: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,9 @@ jwt.secret=${jwt.secret}
 stripe.secret.key=${stripe.api.key}
 
 stripe.public.key=pk_test_51R9WcdRZasVs4eMEw15lLyzEOEO01CsAB3ybTAYUkxubljPdEZNa8vuHZ0i9OrejIx14IDWMeCL4FlBXF6sL6huA00lOINBLtg
+
+# Kafka
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
+


### PR DESCRIPTION
# Kafka Payment Confirmation Integration

This PR introduces Kafka integration to the **ecommerce-payment-service**, enabling asynchronous communication between services for payment confirmation events.

---

##  What's Included

- **Kafka Configuration:**
  - Added `KafkaProducerConfig` to configure producer factory and `KafkaTemplate`
  - Configurable Kafka bootstrap server and serializers in `application.properties`

- **Event Publishing:**
  - Implemented `PaymentEventPublisher` service
  - Publishes `payment-confirmed` events to Kafka topic after successful Stripe payment

- **DTO:**
  - Added `PaymentConfirmedEvent` DTO for structured Kafka payload

- **Payment Flow Update:**
  - Enhanced `processPayment()` to:
    - Trigger Stripe payment
    - Send `payment-confirmed` Kafka event with `orderId` and status